### PR TITLE
Fixed possible wrong "Duplicate paths present" error with replacement rules

### DIFF
--- a/j2cl-maven-plugin/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
+++ b/j2cl-maven-plugin/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
@@ -354,7 +354,9 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
             Dependency dep = new Dependency();
             dep.setProject(child);
             dep.setScope(translateScope(mavenDependency.getScope()));
-            dependencies.add(dep);
+            // Although this new dependency is generally unique, the replacement mechanism may introduce a duplicate
+            // dependency if several original artifacts are replaced with the same final artifact.
+            addDependencyResolveDuplicate(dep, dependencies); // ensures we don't introduce duplicates (important for J2CL)
         }
         project.setDependencies(dependencies);
 
@@ -379,6 +381,23 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
         builtProjects.put(key, project);
 
         return project;
+    }
+
+    private static void addDependencyResolveDuplicate(Dependency newDep, List<Dependency> dependencies) {
+        // We check if there is already an existing dependency in the list with the same project
+        for (int i = 0; i < dependencies.size(); i++) {
+            Dependency existingDep = dependencies.get(i);
+            if (Objects.equals(newDep.getProject(), existingDep.getProject())) {
+                // If we found one, we must keep only 1 dependency. The 2 can differ only by the scope, which has only 2
+                // possible values here: COMPILE or BOTH. BOTH is the one to keep in case of duplicates.
+                if (newDep.getScope() == Dependency.Scope.BOTH) {
+                    dependencies.set(i, newDep);
+                }
+                return;
+            }
+        }
+        // If we reach this point, it means there was no existing dependency with the same project in the list
+        dependencies.add(newDep); // So we can add it
     }
 
     private MavenProject resolveNonReactorProjectForArtifact(ProjectBuilder projectBuilder, ProjectBuildingRequest request, Artifact mavenDependency) throws ProjectBuildingException {


### PR DESCRIPTION
When different replacement rules replace different artifacts with a same single artifact, the plugin is raising a "Duplicate paths present" error, while it's not actually true.

An example of such rules can be found [here](https://github.com/webfx-project/webfx-parent/blob/a359f7fb7a1c2bd2ed613b2a4998242060f0bbd3/pom.xml#L648).

This PR is actually a repeat of my [contribution](https://github.com/Vertispan/j2clmavenplugin/pull/259) to the Vertispan plugin.