### PR TITLE
Added GWT >= 2.10 replacements

### DIFF
--- a/j2cl-maven-plugin/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
+++ b/j2cl-maven-plugin/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
@@ -115,6 +115,11 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
     private List<DependencyReplacement> defaultDependencyReplacements = Arrays.asList(
             new DependencyReplacement("com.google.jsinterop:base", "org.kie.j2cl.tools.jsinterop:base:" + Versions.VERTISPAN_JSINTEROP_BASE_VERSION),
             new DependencyReplacement("org.realityforge.com.google.jsinterop:base", "org.kie.j2cl.tools.jsinterop:base:" + Versions.VERTISPAN_JSINTEROP_BASE_VERSION),
+            // New GWT groupId since GWT 2.10
+            new DependencyReplacement("org.gwtproject:gwt-user", null),
+            new DependencyReplacement("org.gwtproject:gwt-dev", null),
+            new DependencyReplacement("org.gwtproject:gwt-servlet", null),
+            // Old GWT groupId before GWT 2.10
             new DependencyReplacement("com.google.gwt:gwt-user", null),
             new DependencyReplacement("com.google.gwt:gwt-dev", null),
             new DependencyReplacement("com.google.gwt:gwt-servlet", null)


### PR DESCRIPTION
See [Release Notes for 2.10.0](https://www.gwtproject.org/release-notes.html#Release_Notes_2_10_0)

> Maven` groupId is formally changed to org.gwtproject, projects should take care to make sure they are using either the old com.google.gwt:gwt BOM or the new org.gwtproject:gwt BOM to sure that Maven or Gradle correctly handle this change. This will be the last published version using the com.google.gwt groupId.


This PR is actually a repeat of my [contribution](https://github.com/Vertispan/j2clmavenplugin/pull/264) to the Vertispan plugin.